### PR TITLE
Include buried cards in load calculation

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -12,11 +12,11 @@ import time
 def dailyLoad(did: int) -> int:
     '''Takes in a number deck id, returns the estimated load in reviews per day'''
     subdeck_id = ids2str(mw.col.decks.deck_and_child_ids(did))
-    return int(mw.col.db.first(
+    return round(mw.col.db.first(
         f"""
     SELECT SUM(1.0 / max(1, ivl))
-    FROM cards c1
-    WHERE queue >= 1
+    FROM cards
+    WHERE queue != 0 AND queue != -1
     AND did IN {subdeck_id}
     """
     )[0] or 0)


### PR DESCRIPTION
- Also change int to round. If load is 100.9, it is better to take it as 101 rather than 100.