### PR TITLE
Add number of cards introduced today & Exclude suspended cards

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -51,11 +51,11 @@ def updateLimits(hookEnabledConfigKey=None, forceUpdate=False) -> None:
             continue
 
         deckConfig = mw.col.decks.config_dict_for_deck_id(deckIndentifer.id)
-        deck_size = len(list(mw.col.find_cards(f'deck:"{deckIndentifer.name}"')))
+        deck_size = len(list(mw.col.find_cards(f'deck:"{deckIndentifer.name}" -is:suspended')))
         introduced_today = len(list(mw.col.find_cards(f'deck:"{deckIndentifer.name}" introduced:1')))
 
         youngCardLimit = addonConfigLimits.get('youngCardLimit', 999999999)
-        youngCount = 0 if youngCardLimit > deck_size else len(list(mw.col.find_cards(f'deck:"{deckIndentifer.name}" prop:due<21 prop:ivl<21')))
+        youngCount = 0 if youngCardLimit > deck_size else len(list(mw.col.find_cards(f'deck:"{deckIndentifer.name}" prop:due<21 prop:ivl<21 -is:suspended')))
 
         loadLimit = addonConfigLimits.get('loadLimit', 999999999)
         load = 0 if loadLimit > deck_size else dailyLoad(deckIndentifer.id)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -52,6 +52,7 @@ def updateLimits(hookEnabledConfigKey=None, forceUpdate=False) -> None:
 
         deckConfig = mw.col.decks.config_dict_for_deck_id(deckIndentifer.id)
         deck_size = len(list(mw.col.find_cards(f'deck:"{deckIndentifer.name}"')))
+        introduced_today = len(list(mw.col.find_cards(f'deck:"{deckIndentifer.name}" introduced:1')))
 
         youngCardLimit = addonConfigLimits.get('youngCardLimit', 999999999)
         youngCount = 0 if youngCardLimit > deck_size else len(list(mw.col.find_cards(f'deck:"{deckIndentifer.name}" prop:due<21 prop:ivl<21')))
@@ -61,7 +62,7 @@ def updateLimits(hookEnabledConfigKey=None, forceUpdate=False) -> None:
 
         maxNewCardsPerDay = deckConfig['new']['perDay']
 
-        newLimit = max(0, min(maxNewCardsPerDay, youngCardLimit - youngCount, loadLimit - load))
+        newLimit = max(0, min(maxNewCardsPerDay - introduced_today, youngCardLimit - youngCount, loadLimit - load)) + introduced_today
 
         deck["newLimitToday"] = {"limit": newLimit, "today": mw.col.sched.today}
         mw.col.decks.save(deck)


### PR DESCRIPTION
Let's say that my new card limit is set to 50 cards. I do some cards, including 30 new cards. Then, I recalculate my new card limit using the add-on. Now, the add-on calculates that I can do 15 more new cards. But if it sets the limit to 15, Anki won't show me any new cards. To get 15 more cards, the limit should be set to 30 + 15 = 45.

I haven't tested this. So, please test it before merging.