### PR TITLE
Match Anki's definition of Young cards

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -55,7 +55,7 @@ def updateLimits(hookEnabledConfigKey=None, forceUpdate=False) -> None:
         introduced_today = len(list(mw.col.find_cards(f'deck:"{deckIndentifer.name}" introduced:1')))
 
         youngCardLimit = addonConfigLimits.get('youngCardLimit', 999999999)
-        youngCount = 0 if youngCardLimit > deck_size else len(list(mw.col.find_cards(f'deck:"{deckIndentifer.name}" prop:ivl>0 prop:ivl<21 -is:suspended')))
+        youngCount = 0 if youngCardLimit > deck_size else len(list(mw.col.find_cards(f'deck:"{deckIndentifer.name}" -is:learn is:review prop:ivl<21 -is:suspended')))
 
         loadLimit = addonConfigLimits.get('loadLimit', 999999999)
         load = 0 if loadLimit > deck_size else dailyLoad(deckIndentifer.id)


### PR DESCRIPTION
https://github.com/ankitects/anki/blob/c7556f17e6a473c93fe1553e1d883c8937511cf9/rslib/src/stats/graphs/card_counts.rs#L35-L54

To get cards with `CardType::Review`, we need to search `-is:learn is:review`.