### PR TITLE
Round new_limit persisted output

### DIFF
--- a/src/limit.py
+++ b/src/limit.py
@@ -94,7 +94,7 @@ def update_limits(anki: Anki, hook_enabled_config_key: str | None = None, force_
         new_limit = max(0, minimum - new_today, min(max_new_cards_per_day - new_today, effective_config_limit) + new_today)
 
         if not(limit_already_set and deck["newLimitToday"]["limit"] == new_limit):
-            deck["newLimitToday"] = {"limit": new_limit, "today": today}
+            deck["newLimitToday"] = {"limit": round(new_limit), "today": today}
             anki.save_deck(deck)
             limits_changed += 1
 

--- a/test.py
+++ b/test.py
@@ -174,6 +174,16 @@ class Test(unittest.TestCase):
         update_limits(anki, force_update=True)
         self.assertEqual(5, deck['newLimitToday']['limit'], 'max new should match "this deck" over "preset" when defined')
 
+    def test_floating_point_limits_persisted_as_integers(self: Self) -> None:
+        soon_limit = create_mock_deck(id=1, name='A', cards=1000, young=0, load=0.0, soon=100, new=None, new_limit=None, max_new=10)
+        young_limit = create_mock_deck(id=2, name='B', cards=1000, young=100, load=0.0, soon=0, new=None, new_limit=None, max_new=10)
+        limit = create_mock_limit(deck_names=['A', 'B'], young=105.2, soon=105.2)
+        anki = create_mock_anki([limit], [soon_limit, young_limit])
+
+        update_limits(anki, force_update=True)
+
+        self.assertEqual(5, soon_limit['newLimitToday']['limit'], 'soon_limit: 105.2 - 100 == 5 (not 5.2)')
+        self.assertEqual(5, young_limit['newLimitToday']['limit'], 'young_limit: 105.2 - 100 == 5 (not 5.2)')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
While using the young card limit of `375.0` with a deck that had 361 young cards and 20 new cards per day, I noticed the plugin wasn't throttling gradually. Figuring it may only throttling after the limit is passed, I tried `360.0` and noticed it immediately went to 0. Trying to get gradual behavior I did some digging around the plugin.

It turns out, since the config value was a float, the computed `new_limit` came out to `14.0`. The problem is that when persisting this new limit with `deck["newLimitToday"] = { "limit": new_limit, ... }`, Anki silently ignores floating-point values of the limit, so this ends up being equivalent to no limit being applied.

This commit rounds the limit to an integer before storage, to ensure it's persisted regardless of any other floating-point weirdness. As a workaround, one should ensure their config only uses integer limits, at least for the young and soon limits since the load limit is `math.ceil`ed before storage.